### PR TITLE
Add MTA deployment support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-18.04
     steps:
-    - uses: citizen-of-planet-earth/cf-cli-action@master
+    - uses: NickChecan/sap-btp-action@master
       with:
         cf_api: ${{ secrets.CF_API }}
         cf_username: ${{ secrets.CF_USER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,8 @@ RUN echo "deb [trusted=yes] https://packages.cloudfoundry.org/debian stable main
 RUN apt-get update
 RUN apt-get install -y cf7-cli
 
+# Add support for MTA deployment
+RUN cf install-plugin multiapps -f
+
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y ca-certificates jq
 
 RUN echo "deb [trusted=yes] https://packages.cloudfoundry.org/debian stable main" > /etc/apt/sources.list.d/cloudfoundry-cli.list
 RUN apt-get update
-RUN apt-get install -y cf7-cli
+RUN apt-get install -y cf8-cli
 
 # Add support for MTA deployment
 RUN cf install-plugin multiapps -f

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# CF CLI Action
-Deploy to Cloud Foundry and manage your apps and services using the CF CLI easily with this GitHub Action.
+# SAP BTP Action
+Deploy to SAP BTP Cloud Foundry and manage your apps and services using the CF CLI easily with this GitHub Action.
 
 ## Example Workflow
 ```
@@ -20,12 +20,12 @@ jobs:
     needs: build
     
     steps:
-    - uses: citizen-of-planet-earth/cf-cli-action@master
+    - uses: NickChecan/sap-btp-action
       with:
         cf_api: https://api.my-cloud-foundry.com
         cf_username: ${{ secrets.CF_USER }}
         cf_password: ${{ secrets.CF_PASSWORD }}
         cf_org: AwesomeApp
         cf_space: Development
-        command: push -f manifest-dev.yml
+        command: deploy ./project.mtar -f
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: "CF CLI Action"
-description: "Deploy and manage Cloud Foundry using the cf cli"
+name: "SAP BTP Action"
+description: "Deploy and manage SAP BTP Cloud Foundry using the cf cli"
 branding:
   icon: "upload-cloud"
   color: "blue"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ if [ -n "$INPUT_CF_ORG" ] && [ -n "$INPUT_CF_SPACE" ]; then
   cf target -o "$INPUT_CF_ORG" -s "$INPUT_CF_SPACE"
 fi
 
-sh -c "cf7 $*"
+sh -c "cf $*"


### PR DESCRIPTION
Enable users to manage and deploy Multi Target Applications on a Cloud Foundry environment.

Plugin repo: https://github.com/cloudfoundry/multiapps-cli-plugin

Reason: To deploy MTAR files, it is necessary to use the "deploy" command available through the MultiApps plugin for the Cloud Foundry CLI.